### PR TITLE
Fix: Type error on Svelte 4

### DIFF
--- a/packages/svelte-grid/src/index.d.ts
+++ b/packages/svelte-grid/src/index.d.ts
@@ -4,6 +4,7 @@ import VanillaGrid, {
 } from "@egjs/grid";
 import type { SvelteComponent } from "svelte";
 
+
 export default abstract class Grid<T extends GridOptions> extends SvelteComponent {
   $$prop_def: T;
   getInstance(): VanillaGrid;

--- a/packages/svelte-grid/src/index.d.ts
+++ b/packages/svelte-grid/src/index.d.ts
@@ -2,10 +2,9 @@ import VanillaGrid, {
   FrameGridOptions, GridMethods, GridOptions, JustifiedGridOptions,
   MasonryGridOptions, PackingGridOptions,
 } from "@egjs/grid";
-import { SvelteComponentDev } from "svelte/internal";
+import type { SvelteComponent } from "svelte";
 
-
-export default abstract class Grid<T extends GridOptions> extends SvelteComponentDev {
+export default abstract class Grid<T extends GridOptions> extends SvelteComponent {
   $$prop_def: T;
   getInstance(): VanillaGrid;
 }


### PR DESCRIPTION
## Issue

On Svelte 4, I'm getting type errors when using the component `MasonryGrid`:

```
Argument of type 'typeof MasonryGrid' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'
```


## Details

I'm not sure if this is the correct way to fix this but I think `SvelteComponentDev` does not exists anymore. I replaced it with `SvelteComponent` and there are no more type errors.